### PR TITLE
[KAN-36] Update chord definitions to include variable bar heights

### DIFF
--- a/libs/noteable-core/src/lib/canvas/actors/chord-preview.actor.ts
+++ b/libs/noteable-core/src/lib/canvas/actors/chord-preview.actor.ts
@@ -85,17 +85,28 @@ export class ChordPreviewActor extends Actor{
             this.drawLine(ctx, FRAME_X + DELTA_X_AMOUNT*delta, FRAME_Y, FRAME_X + DELTA_X_AMOUNT*delta, FRAME_Y + FRAME_HEIGHT);
         }
 
-        const { fingerPositions , bar} = chord.definitions[0];
+        const { fingerPositions , bar, barHeight} = chord.definitions[0];
         const CHORD_BASE_Y = FRAME_Y + 0.0685*this.height;
 
         if (bar){
             ctx.lineWidth = 0.0685*this.height;
             ctx.lineCap = 'round';
 
-            const EXTENSION = (0.05 * this.width);
+            const EXTENSION = (0.04 * this.width);
             const BAR_X = FRAME_X - (EXTENSION/2);
-            const BAR_WIDTH = FRAME_WIDTH + EXTENSION;
-            this.drawLine(ctx, BAR_X, CHORD_BASE_Y, BAR_X + BAR_WIDTH, CHORD_BASE_Y);
+
+            let BASE_WIDTH = FRAME_WIDTH;
+            let BAR_X_OFFSET = 0;
+
+            if (barHeight) {
+              const NEW_BASE_WIDTH = BASE_WIDTH * (barHeight-1) / 5;
+              BAR_X_OFFSET = BASE_WIDTH - NEW_BASE_WIDTH;
+              BASE_WIDTH = NEW_BASE_WIDTH;
+            }
+
+            const BAR_WIDTH = (BASE_WIDTH + EXTENSION);
+
+            this.drawLine(ctx, BAR_X_OFFSET+BAR_X, CHORD_BASE_Y, BAR_X_OFFSET+BAR_X + BAR_WIDTH, CHORD_BASE_Y);
 
             if (bar !== 1){
               ctx.font = `${Math.floor(0.06 * this.width)}px Verdana`;
@@ -103,7 +114,7 @@ export class ChordPreviewActor extends Actor{
               ctx.textBaseline = 'middle';
               ctx.fillStyle = '#FDFFFC';
 
-              ctx.fillText(String(bar)+'fr', BAR_X + BAR_WIDTH + (this.width * 0.125), CHORD_BASE_Y);
+              ctx.fillText(String(bar)+'fr', BAR_X + FRAME_WIDTH + (this.width * 0.125), CHORD_BASE_Y);
             }
         }
 

--- a/libs/realistic-mock-data/src/lib/mock/chords.ts
+++ b/libs/realistic-mock-data/src/lib/mock/chords.ts
@@ -18,6 +18,7 @@ const C:Chord = {
 
 const Cs_DEF: GuitarChordDefinition = {
   bar: 4,
+  barHeight: 5,
   fingerPositions: [
     { string: 2, fret: 3 },
     { string: 3, fret: 3 },
@@ -149,6 +150,7 @@ const A: Chord = {
 
 const As_DEF: GuitarChordDefinition = {
   bar: 1,
+  barHeight: 5,
   fingerPositions: [
     { string: 2, fret: 3 },
     { string: 3, fret: 3 },
@@ -164,6 +166,7 @@ const As: Chord = {
 
 const B_DEF: GuitarChordDefinition = {
   bar: 2,
+  barHeight: 5,
   fingerPositions: [
     { string: 2, fret: 3 },
     { string: 3, fret: 3 },
@@ -181,6 +184,7 @@ const B: Chord = {
 
 const Cm_DEF: GuitarChordDefinition = {
   bar: 3,
+  barHeight: 5,
   fingerPositions: [
     {string: 2, fret: 2},
     {string: 3, fret: 3},
@@ -196,6 +200,7 @@ const Cm: Chord = {
 
 const Csm_DEF: GuitarChordDefinition = {
   bar: 4,
+  barHeight: 5,
   fingerPositions: [
     {string: 2, fret: 2},
     {string: 3, fret: 3},
@@ -323,6 +328,7 @@ const Am: Chord = {
 
 const Asm_DEF: GuitarChordDefinition = {
   bar: 1,
+  barHeight: 5,
   fingerPositions: [
     { string: 2, fret: 2 },
     { string: 3, fret: 3 },
@@ -338,6 +344,7 @@ const Asm: Chord = {
 
 const Bm_DEF: GuitarChordDefinition = {
     bar: 2,
+    barHeight: 5,
     fingerPositions: [
         { string: 2, fret: 2 },
         { string: 3, fret: 3 },

--- a/libs/types/src/lib/core.ts
+++ b/libs/types/src/lib/core.ts
@@ -109,6 +109,7 @@ interface IChordDefinition{
 
 export interface GuitarChordDefinition extends IChordDefinition{
   bar?: IntRange<1, 24>;
+  barHeight?: IntRange<1, 6>
   fingerPositions: FretBoardNote[];
 }
 


### PR DESCRIPTION
Related to: [Update chord definitions to include variable bar heights](https://saacostam.atlassian.net/browse/KAN-36?atlOrigin=eyJpIjoiZTkwZDIzZTA1NTMzNDk1YjllYmQ5OTYxOTNhMTBlNzgiLCJwIjoiaiJ9)

- Update type of GuitarChordDefinitions
- Update chord preview agent
- Update previously defined chords to include variable bar heights if necessary