### PR TITLE
[KAN-42] Add the option to specify the fret when defining a chord

### DIFF
--- a/libs/noteable-core/src/lib/canvas/actors/chord-preview.actor.ts
+++ b/libs/noteable-core/src/lib/canvas/actors/chord-preview.actor.ts
@@ -85,7 +85,13 @@ export class ChordPreviewActor extends Actor{
             this.drawLine(ctx, FRAME_X + DELTA_X_AMOUNT*delta, FRAME_Y, FRAME_X + DELTA_X_AMOUNT*delta, FRAME_Y + FRAME_HEIGHT);
         }
 
-        const { fingerPositions , bar, barHeight, mutedStrings} = chord.definitions[0];
+        const {
+          fingerPositions ,
+          bar,
+          barHeight,
+          mutedStrings,
+          initialFret,
+        } = chord.definitions[0];
         const CHORD_BASE_Y = FRAME_Y + 0.0685*this.height;
 
         // Bar
@@ -115,8 +121,15 @@ export class ChordPreviewActor extends Actor{
               ctx.textBaseline = 'middle';
               ctx.fillStyle = '#FDFFFC';
 
-              ctx.fillText(String(bar)+'fr', BAR_X + FRAME_WIDTH + (this.width * 0.125), CHORD_BASE_Y);
+              ctx.fillText(String(bar)+'fr', FRAME_X + FRAME_WIDTH + (this.width * 0.125), CHORD_BASE_Y);
             }
+        }else if (initialFret){
+          ctx.textBaseline = 'middle';
+          ctx.textAlign = 'center';
+          ctx.font = `${Math.floor(0.06 * this.width)}px Verdana`;
+          ctx.fillStyle = '#FDFFFC';
+
+          ctx.fillText(String(initialFret)+'fr', FRAME_X + FRAME_WIDTH + (this.width * 0.125), CHORD_BASE_Y);
         }
 
         // Finger Positions

--- a/libs/types/src/lib/core.ts
+++ b/libs/types/src/lib/core.ts
@@ -109,6 +109,7 @@ interface IChordDefinition{
 
 export interface GuitarChordDefinition extends IChordDefinition{
   bar?: IntRange<1, 24>;
+  initialFret?: IntRange<1, 24>;
   barHeight?: IntRange<1, 6>;
   mutedStrings?: IntRange<1, 7>[];
   fingerPositions: FretBoardNote[];


### PR DESCRIPTION
- Add the option to specify the fret when defining a chord, as an optional parameter.
- It is shown, only if a bar for the chord was not defined.