### PR TITLE
[KAN-45] Enable to see the tabs of a song in Admin song panel

### DIFF
--- a/apps/noteable/src/views/Admin/Song-[id]/hook.ts
+++ b/apps/noteable/src/views/Admin/Song-[id]/hook.ts
@@ -147,6 +147,7 @@ export function useAdminSongById(){
 
   return useMemo(() => {
     return {
+      songName: songTabs?.name || 'NO_NAME',
       songTabs: songTabs?.tablatures || [],
       getTabsBySongIsLoading: getTabsBySongIsLoading,
       getTabsBySongIsError: getTabsBySongIsError,

--- a/apps/noteable/src/views/Admin/Song-[id]/index.tsx
+++ b/apps/noteable/src/views/Admin/Song-[id]/index.tsx
@@ -1,12 +1,43 @@
 import React from "react";
-import {Button, Divider, Stack} from "@mui/material";
+import {Link} from "react-router-dom";
+import {Button, Divider, List, ListItemButton, ListItemIcon, ListItemText, Stack} from "@mui/material";
+import {LibraryMusic} from "@mui/icons-material";
+
 import {NoteableViewer} from "@noteable/react-components";
 
 import {useAdminSongById} from "./hook";
 import {CreateTabMetaDataSection, CreateMusicUnitsSection} from "./components";
 
+type TabListItemProps = {
+  id: string;
+  songName: string;
+}
+
+export function TabListItem({id, songName}: TabListItemProps){
+  return (
+    <Link
+      to={`/tab/${id}`}
+    >
+      <ListItemButton>
+        <ListItemIcon>
+          <LibraryMusic
+            fontSize={'large'}
+            color={"secondary"}
+          />
+        </ListItemIcon>
+        <ListItemText
+          primary={songName}
+          secondary={id}
+        />
+      </ListItemButton>
+    </Link>
+  )
+}
+
 export function AdminSongById(){
   const {
+    songName,
+    songTabs,
     getTabsBySongIsLoading,
     doCreateTab,
     createTabIsLoading,
@@ -80,6 +111,18 @@ export function AdminSongById(){
               </Button>
             </Stack>
             <Divider variant={"middle"}/>
+            <List
+              dense={true}
+            >
+              {
+                songTabs.map(songTab => (
+                  <TabListItem
+                    id={songTab.id}
+                    songName={songName}
+                  />
+                ))
+              }
+            </List>
           </>
         )
       }

--- a/apps/tabs-service/src/modules/song/song.service.ts
+++ b/apps/tabs-service/src/modules/song/song.service.ts
@@ -1,6 +1,8 @@
-import { Injectable } from '@nestjs/common';
+import {Injectable, NotFoundException} from '@nestjs/common';
+
 import {PrismaService} from "@noteable/be-common";
-import {LeanSong} from "@noteable/types";
+import {GetSongTabsByIdDto} from "@noteable/interfaces";
+import {Decade, Genre, Key, LeanSong} from "@noteable/types";
 
 @Injectable()
 export class SongService {
@@ -27,8 +29,8 @@ export class SongService {
     })
   }
 
-  async getSongTabsById(id: string){
-    return this.prismaService.song.findUnique({
+  async getSongTabsById(id: string): Promise<GetSongTabsByIdDto> {
+    const dbSong = await this.prismaService.song.findUnique({
       where: {
         id: id,
       },
@@ -36,5 +38,14 @@ export class SongService {
         ...this.includeSongWithMinimalTabs,
       }
     })
+
+    if (!dbSong) throw new NotFoundException(`Song with ${id} not found`);
+
+    return {
+      ...dbSong,
+      key: dbSong.key as Key,
+      decade: dbSong.decade as Decade,
+      genre: dbSong.genre as Genre,
+    }
   }
 }

--- a/libs/interfaces/src/lib/index.ts
+++ b/libs/interfaces/src/lib/index.ts
@@ -1,2 +1,3 @@
 export * from './common';
 export * from './dto';
+export * from './response';

--- a/libs/interfaces/src/lib/response/index.ts
+++ b/libs/interfaces/src/lib/response/index.ts
@@ -1,0 +1,1 @@
+export * from './tab';

--- a/libs/interfaces/src/lib/response/tab/get-song-tabs-by-id.dto.ts
+++ b/libs/interfaces/src/lib/response/tab/get-song-tabs-by-id.dto.ts
@@ -1,0 +1,8 @@
+import {Song} from "@noteable/types";
+
+export type GetSongTabsByIdDto = Omit<Song, 'artists'> & {
+  artistsIDs: string[];
+  tablatures: Array<{
+    id: string;
+  }>
+}

--- a/libs/interfaces/src/lib/response/tab/index.ts
+++ b/libs/interfaces/src/lib/response/tab/index.ts
@@ -1,0 +1,1 @@
+export * from './get-song-tabs-by-id.dto';


### PR DESCRIPTION
[[KAN-45]](https://saacostam.atlassian.net/browse/KAN-45?atlOrigin=eyJpIjoiYTdmZTA1MDgyMTI3NDI3ODhlMTVkZDgwZTNiMjYwMDciLCJwIjoiaiJ9) Enable to see the tabs of a song in Admin song panel

# Description
- Enable to see the tabs of a song in Admin song panel
- Define first query as a dto.
    - The db returns a string as defined in the prisma schema, so it is asserted that the payload is part of one of the string union types. 
    - It's fine, but defining an enum in prisma schema might be better for full-stack type safety. Not entirely sure.